### PR TITLE
Adopt BIP85 PGP paths and add fingerprint CLI

### DIFF
--- a/scripts/pgp_fingerprint.py
+++ b/scripts/pgp_fingerprint.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Derive a deterministic PGP fingerprint from a BIP39 mnemonic."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_PATH = REPO_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
+from bip_utils import Bip39SeedGenerator  # noqa: E402
+
+from local_bip85.bip85 import BIP85  # noqa: E402
+from seedpass.core.password_generation import derive_pgp_key  # noqa: E402
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Derive a deterministic OpenPGP fingerprint using the BIP-85 PGP"
+            " derivation paths."
+        )
+    )
+    parser.add_argument(
+        "mnemonic",
+        help="BIP39 mnemonic that seeds the derivation.",
+    )
+    parser.add_argument(
+        "-i",
+        "--index",
+        type=int,
+        default=0,
+        help="Derivation index to use (defaults to 0).",
+    )
+    parser.add_argument(
+        "-t",
+        "--key-type",
+        default="ed25519",
+        help=(
+            "PGP key type to derive (e.g. 'ed25519', 'curve25519', 'rsa',"
+            " 'rsa-4096')."
+        ),
+    )
+    parser.add_argument(
+        "-u",
+        "--user-id",
+        default="",
+        help="Optional user ID to attach to the generated key.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    try:
+        seed_bytes = Bip39SeedGenerator(args.mnemonic).Generate()
+        bip85 = BIP85(seed_bytes)
+        _, fingerprint = derive_pgp_key(
+            bip85,
+            args.index,
+            key_type=args.key_type,
+            user_id=args.user_id,
+        )
+    except Exception as exc:  # pragma: no cover - CLI convenience
+        print(f"Error: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+
+    print(fingerprint)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/local_bip85/bip85.py
+++ b/src/local_bip85/bip85.py
@@ -51,32 +51,13 @@ class BIP85:
             print(f"{Fore.RED}Error initializing BIP32 context: {e}")
             raise Bip85Error(f"Error initializing BIP32 context: {e}")
 
-    def derive_entropy(
-        self, index: int, bytes_len: int, app_no: int = 39, words_len: int | None = None
-    ) -> bytes:
-        """
-        Derives entropy using BIP-85 HMAC-SHA512 method.
+    def _derive_entropy_for_path(self, path: str, bytes_len: int) -> bytes:
+        """Derive entropy for an explicit derivation path."""
 
-        Parameters:
-            index (int): Index for the child entropy.
-            bytes_len (int): Number of bytes to derive for the entropy.
-            app_no (int): Application number (default 39 for BIP39)
-
-        Returns:
-            bytes: Derived entropy.
-
-        Raises:
-            SystemExit: If derivation fails or entropy length is invalid.
-        """
-        if app_no == 39:
-            if words_len is None:
-                words_len = bytes_len
-            path = f"m/83696968'/{app_no}'/0'/{words_len}'/{index}'"
-        elif app_no == 32:
-            path = f"m/83696968'/{app_no}'/{index}'"
-        else:
-            # Handle other app_no if necessary
-            path = f"m/83696968'/{app_no}'/{index}'"
+        if not 1 <= bytes_len <= 64:
+            raise Bip85Error(
+                f"Invalid entropy length {bytes_len}; supported range is 1-64 bytes."
+            )
 
         try:
             child_key = self.bip32_ctx.DerivePath(path)
@@ -106,6 +87,40 @@ class BIP85:
             logging.error(f"Error deriving entropy: {e}", exc_info=True)
             print(f"{Fore.RED}Error deriving entropy: {e}")
             raise Bip85Error(f"Error deriving entropy: {e}")
+
+    def derive_entropy(
+        self, index: int, bytes_len: int, app_no: int = 39, words_len: int | None = None
+    ) -> bytes:
+        """
+        Derives entropy using BIP-85 HMAC-SHA512 method.
+
+        Parameters:
+            index (int): Index for the child entropy.
+            bytes_len (int): Number of bytes to derive for the entropy.
+            app_no (int): Application number (default 39 for BIP39)
+
+        Returns:
+            bytes: Derived entropy.
+
+        Raises:
+            SystemExit: If derivation fails or entropy length is invalid.
+        """
+        if app_no == 39:
+            if words_len is None:
+                words_len = bytes_len
+            path = f"m/83696968'/{app_no}'/0'/{words_len}'/{index}'"
+        elif app_no == 32:
+            path = f"m/83696968'/{app_no}'/{index}'"
+        else:
+            # Handle other app_no if necessary
+            path = f"m/83696968'/{app_no}'/{index}'"
+
+        return self._derive_entropy_for_path(path, bytes_len)
+
+    def derive_entropy_from_path(self, path: str, bytes_len: int) -> bytes:
+        """Derive entropy using an explicit BIP85 path."""
+
+        return self._derive_entropy_for_path(path, bytes_len)
 
     def derive_mnemonic(self, index: int, words_num: int) -> str:
         bytes_len = {12: 16, 18: 24, 24: 32}.get(words_num)

--- a/src/seedpass/core/password_generation.py
+++ b/src/seedpass/core/password_generation.py
@@ -54,6 +54,73 @@ from .encryption import EncryptionManager
 logger = logging.getLogger(__name__)
 
 
+_BIP85_APPLICATION_ROOT = 83696968
+
+
+@dataclass(frozen=True)
+class _PGPKeyTypeConfig:
+    app_no: int
+    default_bits: int
+    allows_custom_bits: bool
+
+
+_PGP_KEY_TYPE_INFO: dict[str, _PGPKeyTypeConfig] = {
+    "rsa": _PGPKeyTypeConfig(app_no=828365, default_bits=2048, allows_custom_bits=True),
+    "ed25519": _PGPKeyTypeConfig(
+        app_no=828366, default_bits=256, allows_custom_bits=False
+    ),
+}
+
+_PGP_KEY_TYPE_ALIASES = {
+    "curve25519": "ed25519",
+}
+
+
+def _parse_pgp_key_type(key_type: str) -> tuple[str, _PGPKeyTypeConfig, int]:
+    """Normalize the requested key type and extract the key size."""
+
+    if not key_type or not key_type.strip():
+        raise ValueError("PGP key type must be provided")
+
+    raw = key_type.strip().lower()
+    bits: int | None = None
+
+    for sep in (":", "-"):
+        if sep in raw:
+            base, suffix = raw.split(sep, 1)
+            if suffix.isdigit():
+                bits = int(suffix)
+                raw = base
+            else:
+                raw = base
+            break
+
+    normalized = _PGP_KEY_TYPE_ALIASES.get(raw, raw)
+    config = _PGP_KEY_TYPE_INFO.get(normalized)
+    if config is None:
+        supported = ", ".join(sorted(_PGP_KEY_TYPE_INFO))
+        raise ValueError(
+            f"Unsupported PGP key type '{key_type}'. Supported types: {supported}"
+        )
+
+    if bits is None:
+        bits = config.default_bits
+    else:
+        if bits <= 0:
+            raise ValueError("PGP key size must be a positive integer")
+        if not config.allows_custom_bits and bits != config.default_bits:
+            raise ValueError(
+                f"Key type '{normalized}' does not support custom key sizes"
+            )
+        if config.allows_custom_bits:
+            if bits < 2048:
+                raise ValueError("RSA key size must be at least 2048 bits")
+            if bits % 256 != 0:
+                raise ValueError("RSA key size must be a multiple of 256 bits")
+
+    return normalized, config, bits
+
+
 @dataclass
 class PasswordPolicy:
     """Minimum complexity requirements for generated passwords.
@@ -459,6 +526,11 @@ def derive_pgp_key(
 ) -> tuple[str, str]:
     """Derive a deterministic PGP private key and return it with its fingerprint."""
 
+    if idx < 0:
+        raise ValueError("Derivation index must be non-negative")
+
+    normalized_type, config, key_bits = _parse_pgp_key_type(key_type)
+
     from pgpy import PGPKey, PGPUID
     from pgpy.packet.packets import PrivKeyV4
     from pgpy.packet.fields import (
@@ -480,26 +552,25 @@ def derive_pgp_key(
     from Crypto.Util.number import inverse
     from cryptography.hazmat.primitives.asymmetric import ed25519
     from cryptography.hazmat.primitives import serialization
-    import hashlib
     import datetime
 
-    entropy = bip85.derive_entropy(index=idx, bytes_len=32, app_no=32)
-    created = datetime.datetime(2000, 1, 1, tzinfo=datetime.timezone.utc)
+    path = f"m/{_BIP85_APPLICATION_ROOT}'/{config.app_no}'/{key_bits}'/{idx}'"
+    entropy = bip85.derive_entropy_from_path(path, bytes_len=64)
+    created = datetime.datetime(2009, 1, 3, 18, 5, 5, tzinfo=datetime.timezone.utc)
 
-    if key_type.lower() == "rsa":
+    if normalized_type == "rsa":
+        from Crypto.Hash import SHAKE256
 
-        class DRNG:
+        class BIP85DRNG:
             def __init__(self, seed: bytes) -> None:
-                self.seed = seed
+                if len(seed) != 64:
+                    raise ValueError("RSA key derivation requires 64 bytes of entropy")
+                self._shake = SHAKE256.new(data=seed)
 
             def __call__(self, n: int) -> bytes:  # pragma: no cover - deterministic
-                out = b""
-                while len(out) < n:
-                    self.seed = hashlib.sha256(self.seed).digest()
-                    out += self.seed
-                return out[:n]
+                return self._shake.read(n)
 
-        rsa_key = RSA.generate(2048, randfunc=DRNG(entropy))
+        rsa_key = RSA.generate(key_bits, randfunc=BIP85DRNG(entropy))
         keymat = RSAPriv()
         keymat.n = MPI(rsa_key.n)
         keymat.e = MPI(rsa_key.e)
@@ -513,13 +584,14 @@ def derive_pgp_key(
         pkt.pkalg = PubKeyAlgorithm.RSAEncryptOrSign
         pkt.keymaterial = keymat
     else:
-        priv = ed25519.Ed25519PrivateKey.from_private_bytes(entropy)
+        seed_material = entropy[:32]
+        priv = ed25519.Ed25519PrivateKey.from_private_bytes(seed_material)
         public = priv.public_key().public_bytes(
             serialization.Encoding.Raw, serialization.PublicFormat.Raw
         )
         keymat = EdDSAPriv()
         keymat.oid = EllipticCurveOID.Ed25519
-        keymat.s = MPI(int.from_bytes(entropy, "big"))
+        keymat.s = MPI(int.from_bytes(seed_material, "big"))
         keymat.p = ECPoint.from_values(
             keymat.oid.key_size, ECPointFormat.Native, public
         )

--- a/src/seedpass/core/password_generation.py
+++ b/src/seedpass/core/password_generation.py
@@ -20,6 +20,7 @@ import string
 import random
 import traceback
 import base64
+import datetime
 from typing import Optional
 from dataclasses import dataclass
 from termcolor import colored
@@ -55,6 +56,7 @@ logger = logging.getLogger(__name__)
 
 
 _BIP85_APPLICATION_ROOT = 83696968
+BITCOIN_GENESIS_TIMESTAMP = 1231006505
 
 
 @dataclass(frozen=True)
@@ -552,11 +554,12 @@ def derive_pgp_key(
     from Crypto.Util.number import inverse
     from cryptography.hazmat.primitives.asymmetric import ed25519
     from cryptography.hazmat.primitives import serialization
-    import datetime
 
     path = f"m/{_BIP85_APPLICATION_ROOT}'/{config.app_no}'/{key_bits}'/{idx}'"
     entropy = bip85.derive_entropy_from_path(path, bytes_len=64)
-    created = datetime.datetime(2009, 1, 3, 18, 5, 5, tzinfo=datetime.timezone.utc)
+    created = datetime.datetime.fromtimestamp(
+        BITCOIN_GENESIS_TIMESTAMP, tz=datetime.timezone.utc
+    )
 
     if normalized_type == "rsa":
         from Crypto.Hash import SHAKE256

--- a/src/tests/test_pgp_entry.py
+++ b/src/tests/test_pgp_entry.py
@@ -27,7 +27,7 @@ def test_pgp_key_determinism():
 
         assert fp1 == fp2
         assert key1 == key2
-        assert fp1 == "0D973716792FBF2CAD1BD5E624BDD87CADFFAFFE"
+        assert fp1 == "9837B7E85F711F478DBE22EB641301EA97DA37C5"
 
         # parse returned armored key and verify fingerprint
         from pgpy import PGPKey
@@ -58,7 +58,7 @@ def test_pgp_rsa_key_determinism():
 
         assert fp1 == fp2
         assert key1 == key2
-        assert fp1 == "AAFBC88EB258406A831E84051EA43E0D063C7676"
+        assert fp1 == "ECC1557BE1B91255FAC1BB370ABFE55998DF2870"
 
         from pgpy import PGPKey
 

--- a/src/tests/test_pgp_entry.py
+++ b/src/tests/test_pgp_entry.py
@@ -2,6 +2,8 @@ import sys
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+import pytest
+
 from helpers import create_vault, TEST_SEED, TEST_PASSWORD
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
@@ -9,6 +11,35 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 from seedpass.core.entry_management import EntryManager
 from seedpass.core.backup import BackupManager
 from seedpass.core.config_manager import ConfigManager
+
+
+@pytest.mark.parametrize(
+    ("key_type", "expected_fingerprint"),
+    [
+        ("ed25519", "9837B7E85F711F478DBE22EB641301EA97DA37C5"),
+        ("curve25519", "9837B7E85F711F478DBE22EB641301EA97DA37C5"),
+        ("rsa", "ECC1557BE1B91255FAC1BB370ABFE55998DF2870"),
+        ("rsa-4096", "6784BC8345BAEF74ED426F55903131B578BB929C"),
+    ],
+)
+def test_pgp_derivation_vectors(key_type: str, expected_fingerprint: str) -> None:
+    from bip_utils import Bip39SeedGenerator
+
+    from local_bip85.bip85 import BIP85
+    from seedpass.core.password_generation import derive_pgp_key
+    from pgpy import PGPKey
+
+    seed_bytes = Bip39SeedGenerator(TEST_SEED).Generate()
+    bip85 = BIP85(seed_bytes)
+
+    armored_key, fingerprint = derive_pgp_key(
+        bip85, 0, key_type=key_type, user_id="Vector Test"
+    )
+
+    assert fingerprint == expected_fingerprint
+
+    parsed_key, _ = PGPKey.from_blob(armored_key)
+    assert parsed_key.fingerprint == expected_fingerprint
 
 
 def test_pgp_key_determinism():

--- a/src/tests/test_pgp_entry.py
+++ b/src/tests/test_pgp_entry.py
@@ -27,6 +27,7 @@ def test_pgp_key_determinism():
 
         assert fp1 == fp2
         assert key1 == key2
+        assert fp1 == "0D973716792FBF2CAD1BD5E624BDD87CADFFAFFE"
 
         # parse returned armored key and verify fingerprint
         from pgpy import PGPKey
@@ -39,3 +40,27 @@ def test_pgp_key_determinism():
         entry = data["entries"][str(idx)]
         assert entry["key_type"] == "ed25519"
         assert entry["user_id"] == "Test"
+
+
+def test_pgp_rsa_key_determinism():
+    with TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        vault, enc_mgr = create_vault(tmp_path, TEST_SEED, TEST_PASSWORD)
+        cfg_mgr = ConfigManager(vault, tmp_path)
+        backup_mgr = BackupManager(tmp_path, cfg_mgr)
+        entry_mgr = EntryManager(vault, backup_mgr)
+
+        idx = entry_mgr.add_pgp_key(
+            "pgp-rsa", TEST_SEED, key_type="rsa", user_id="RSA Test"
+        )
+        key1, fp1 = entry_mgr.get_pgp_key(idx, TEST_SEED)
+        key2, fp2 = entry_mgr.get_pgp_key(idx, TEST_SEED)
+
+        assert fp1 == fp2
+        assert key1 == key2
+        assert fp1 == "AAFBC88EB258406A831E84051EA43E0D063C7676"
+
+        from pgpy import PGPKey
+
+        parsed_key, _ = PGPKey.from_blob(key1)
+        assert parsed_key.fingerprint == fp1


### PR DESCRIPTION
## Summary
- derive PGP keys using the BIP85 GPG application paths with key-type aware sizing and BIP85-DRNG support
- expose the new behaviour through updated deterministic tests for ed25519 and RSA fingerprints
- add a lightweight `scripts/pgp_fingerprint.py` helper to print fingerprints for a mnemonic, index, and key type

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c8ba5a359c83228e610a2016f1c1cd